### PR TITLE
Use target from basic info instead of destination

### DIFF
--- a/src/map/src/systems/movementsystem.cpp
+++ b/src/map/src/systems/movementsystem.cpp
@@ -18,10 +18,7 @@ MovementSystem::MovementSystem(SystemManager &manager) : System(manager) {
     if (auto client = getClient(entity))
       CMapServer::SendPacket(client, CMapServer::eSendType::EVERYONE,
                              *makePacket<ePacketType::PAKWC_STOP_MOVING>(entity));
-    if (dest->target_) {
-      //logger_->warn("picking up the item");
-      // TODO: pickup item
-    }
+    // TODO: check what type entity.component<BasicInfo>()->targetId_ is and execute corresponding action (npc talk, attack, item pickup...)
   });
   // FIXME : use es.on_component_added for Destination? -> what happens if the destination is only updated
 }

--- a/src/map/src/systems/movementsystem.cpp
+++ b/src/map/src/systems/movementsystem.cpp
@@ -59,10 +59,10 @@ void MovementSystem::move(Entity entity, float x, float y, uint16_t target) {
     dest->x_ = x;
     dest->y_ = y;
     dest->dist_ = dist;
-    dest->target_ = target;
   } else {
-    entity.assign<Destination>(x, y, dist, target);
+    entity.assign<Destination>(x, y, dist);
   }
+  entity.component<BasicInfo>()->targetId_ = target;
   // FIXME: what happens if the entity is an NPC or a monster?
   if (auto client = getClient(entity))
     CMapServer::SendPacket(client, CMapServer::eSendType::EVERYONE, *makePacket<ePacketType::PAKWC_MOUSE_CMD>(entity));

--- a/src/rosecommon/include/components/destination.h
+++ b/src/rosecommon/include/components/destination.h
@@ -1,11 +1,10 @@
 #pragma once
 
 struct Destination {
-    Destination(float x, float y, uint16_t dist, uint16_t target = 0) : x_(x), y_(y), dist_(dist), target_(target) {}
+    Destination(float x, float y, uint16_t dist) : x_(x), y_(y), dist_(dist) {}
 
     float x_;
     float y_;
     uint16_t dist_;
-    uint16_t target_;
 };
 

--- a/src/rosecommon/src/packets/srv_mousecmd.cpp
+++ b/src/rosecommon/src/packets/srv_mousecmd.cpp
@@ -17,7 +17,7 @@ void SrvMouseCmd::pack() {
   auto position = entity_.component<Position>();
 
   *this << basicInfo->id_;
-  *this << destination->target_;
+  *this << basicInfo->target_;
   *this << destination->dist_;
   *this << destination->x_;
   *this << destination->y_;

--- a/src/rosecommon/src/packets/srv_mousecmd.cpp
+++ b/src/rosecommon/src/packets/srv_mousecmd.cpp
@@ -17,7 +17,7 @@ void SrvMouseCmd::pack() {
   auto position = entity_.component<Position>();
 
   *this << basicInfo->id_;
-  *this << basicInfo->target_;
+  *this << basicInfo->targetId_;
   *this << destination->dist_;
   *this << destination->x_;
   *this << destination->y_;


### PR DESCRIPTION
We can have a target but not be moving, so it makes more sense to put the target in the `BasicInfo` component as the `Destination` component can be deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dev-osrose/osirose-new/135)
<!-- Reviewable:end -->
