### PR TITLE
Add missing deps to unix setup script

### DIFF
--- a/unix_env_setup.sh
+++ b/unix_env_setup.sh
@@ -2,7 +2,7 @@
 
 sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
 sudo apt-get update
-sudo apt-get install g++-7 unzip autoconf libtool libssl-dev python perl
+sudo apt-get install g++-7 unzip autoconf libtool libssl-dev python perl libncurses5-dev libreadline-dev
 
 git submodule update --init --recursive
 


### PR DESCRIPTION
Closes #141. Following debian/ubuntu deps added:
- libcurses5-dev
- libreadline-dev

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dev-osrose/osirose-new/142)
<!-- Reviewable:end -->
