### PR TITLE
Fix teleporting on the same map

### DIFF
--- a/src/map/src/cmapclient.cpp
+++ b/src/map/src/cmapclient.cpp
@@ -81,7 +81,7 @@ bool CMapClient::handlePacket(uint8_t* _buffer) {
     case ePacketType::PAKCS_CHANGE_CHAR_REQ:
       return changeCharacterReply(Packet::CliChangeCharReq::create(_buffer));
     case ePacketType::PAKCS_CHANGE_MAP_REQ:
-      if (login_state_ != eSTATE::LOGGEDIN) {
+      if (login_state_ != eSTATE::LOGGEDIN && login_state_ != eSTATE::ONMAP) {
         logger_->warn("Client {} is attempting to execute an action before logging in.", get_id());
         return true;
       }


### PR DESCRIPTION
This fixes teleporting on the same map. The issue is that when teleporting on the same map, the clients `login_state_` is not set back to `eSTATE::LOGGEDIN` but keeps its value of `eSTATE::ONMAP`. This fix allows clients with either states to make a map change request.

NOTE: We can safely assume that if the user has an `eSTATE::ONMAP` logged in state then they are already logged into the correct server. Otherwise, their logged in state would have been reset when they disconnected from the previous one.

Fixes #171

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dev-osrose/osirose-new/172)
<!-- Reviewable:end -->
