### PR TITLE
Add bitfields support for structs

### DIFF
--- a/src/rosecommon/include/crosewriter.h
+++ b/src/rosecommon/include/crosewriter.h
@@ -6,14 +6,14 @@ namespace RoseCommon {
 
 class CRoseBasePolicy {
    public:
-       virtual bool set_uint8_t(uint8_t data) = 0;
-       virtual bool set_int8_t(int8_t data) = 0;
-       virtual bool set_uint16_t(uint16_t data) = 0;
-       virtual bool set_int16_t(int16_t data) = 0;
-       virtual bool set_uint32_t(uint32_t data) = 0;
-       virtual bool set_int32_t(int32_t data) = 0;
-       virtual bool set_uint64_t(uint64_t data) = 0;
-       virtual bool set_int64_t(int64_t data) = 0;
+       virtual bool set_uint8_t(uint8_t data, size_t bits=sizeof(uint8_t)) = 0;
+       virtual bool set_int8_t(int8_t data, size_t bits=sizeof(int8_t)) = 0;
+       virtual bool set_uint16_t(uint16_t data, size_t bits=sizeof(uint16_t)) = 0;
+       virtual bool set_int16_t(int16_t data, size_t bits=sizeof(int16_t)) = 0;
+       virtual bool set_uint32_t(uint32_t data, size_t bits=sizeof(uint32_t)) = 0;
+       virtual bool set_int32_t(int32_t data, size_t bits=sizeof(int32_t)) = 0;
+       virtual bool set_uint64_t(uint64_t data, size_t bits=sizeof(uint64_t)) = 0;
+       virtual bool set_int64_t(int64_t data, size_t bits=sizeof(int64_t)) = 0;
        virtual bool set_string(const std::string& data) = 0;
        virtual bool set_string(const std::string& data, size_t size) = 0;
        virtual bool set_float(float data) = 0;
@@ -29,14 +29,14 @@ class CRosePolicy : public CRoseBasePolicy {
     public:
         CRosePolicy(uint8_t *buffer, uint16_t size) : m_current(buffer), m_buffer(buffer), m_size(size) {}
 
-       bool set_uint8_t(uint8_t data) { return write(data); }
-       bool set_int8_t(int8_t data) { return write(data); }
-       bool set_uint16_t(uint16_t data) { return write(data); }
-       bool set_int16_t(int16_t data) { return write(data); }
-       bool set_uint32_t(uint32_t data) { return write(data); }
-       bool set_int32_t(int32_t data) { return write(data); }
-       bool set_uint64_t(uint64_t data) { return write(data); }
-       bool set_int64_t(int64_t data) { return write(data); }
+       bool set_uint8_t(uint8_t data, size_t bits=sizeof(uint8_t)) { return write(data, bits); }
+       bool set_int8_t(int8_t data, size_t bits=sizeof(int8_t)) { return write(data, bits); }
+       bool set_uint16_t(uint16_t data, size_t bits=sizeof(uint16_t)) { return write(data, bits); }
+       bool set_int16_t(int16_t data, size_t bits=sizeof(int16_t)) { return write(data, bits); }
+       bool set_uint32_t(uint32_t data, size_t bits=sizeof(uint32_t)) { return write(data, bits); }
+       bool set_int32_t(int32_t data, size_t bits=sizeof(int32_t)) { return write(data, bits); }
+       bool set_uint64_t(uint64_t data, size_t bits=sizeof(uint64_t)) { return write(data, bits); }
+       bool set_int64_t(int64_t data, size_t bits=sizeof(int64_t)) { return write(data, bits); }
        bool set_string(const std::string& data) {
            for (const char c : data)
                if (!write(c)) return false;
@@ -63,6 +63,12 @@ class CRosePolicy : public CRoseBasePolicy {
             static_assert(std::is_copy_assignable_v<T>, "CRoseWriter doesn't know how to copy assign this type!");
             return Policy::template write(&m_current, m_buffer, &m_size, data);
         }
+        
+        template <typename T>
+        bool write(const T& data, size_t bits) {
+            static_assert(std::is_copy_assignable_v<T>, "CRoseWriter doesn't know how to copy assign this type!");
+            return Policy::template write(&m_current, m_buffer, &m_size, data, bits);
+        }
 };
 
 struct WritePolicy {
@@ -71,6 +77,13 @@ struct WritePolicy {
         if (!*m_current || *m_current + sizeof(T) > m_buffer + *m_size) return false;
         *reinterpret_cast<T*>(*m_current) = data;
         *m_current += sizeof(T);
+        return true;
+    }
+    template <typename T>
+    static bool write(uint8_t** m_current, uint8_t* m_buffer, uint16_t* m_size, const T& data, size_t bits) {
+        if (!*m_current || *m_current + bits > m_buffer + *m_size) return false;
+        *reinterpret_cast<T*>(*m_current) = data;
+        *m_current += bits;
         return true;
     }
 };
@@ -90,14 +103,14 @@ class CRoseReader {
     public:
         CRoseReader(const uint8_t *buffer, uint16_t size) : m_current(buffer), m_buffer(buffer), m_size(size) {}
 
-        bool get_uint8_t(uint8_t& data) { return read(data); }
-        bool get_int8_t(int8_t& data) { return read(data); }
-        bool get_uint16_t(uint16_t& data) { return read(data); }
-        bool get_int16_t(int16_t& data) { return read(data); }
-        bool get_uint32_t(uint32_t& data) { return read(data); }
-        bool get_int32_t(int32_t& data) { return read(data); }
-        bool get_uint64_t(uint64_t& data) { return read(data); }
-        bool get_int64_t(int64_t& data) { return read(data); }
+        bool get_uint8_t(uint8_t& data, size_t bits=sizeof(uint8_t)) { return read(data, bits); }
+        bool get_int8_t(int8_t& data, size_t bits=sizeof(int8_t)) { return read(data, bits); }
+        bool get_uint16_t(uint16_t& data, size_t bits=sizeof(uint16_t)) { return read(data, bits); }
+        bool get_int16_t(int16_t& data, size_t bits=sizeof(int16_t)) { return read(data, bits); }
+        bool get_uint32_t(uint32_t& data, size_t bits=sizeof(uint32_t)) { return read(data, bits); }
+        bool get_int32_t(int32_t& data, size_t bits=sizeof(int32_t)) { return read(data, bits); }
+        bool get_uint64_t(uint64_t& data, size_t bits=sizeof(uint64_t)) { return read(data, bits); }
+        bool get_int64_t(int64_t& data, size_t bits=sizeof(int64_t)) { return read(data, bits); }
         bool get_string(std::string& data) {
             char c = '\0';
             if (!read(c)) return false;
@@ -132,6 +145,14 @@ class CRoseReader {
             if (!m_current || m_current + sizeof(T) > m_buffer + m_size) return false;
             data = *reinterpret_cast<const T* const>(m_current);
             m_current += sizeof(T);
+            return true;
+        }
+        template <typename T>
+        bool read(T& data, size_t bits) {
+            static_assert(std::is_copy_assignable_v<T>, "CRoseReader doesn't know how to copy assign this type!");
+            if (!m_current || m_current + bits > m_buffer + m_size) return false;
+            data = *reinterpret_cast<const T* const>(m_current);
+            m_current += bits;
             return true;
         }
 };

--- a/src/rosecommon/include/crosewriter.h
+++ b/src/rosecommon/include/crosewriter.h
@@ -94,6 +94,11 @@ struct SizePolicy {
         *m_size += sizeof(T);
         return true;
     }
+    template <typename T>
+    static bool write(uint8_t**, uint8_t*, uint16_t* m_size, const T&, size_t bits) {
+        *m_size += bits;
+        return true;
+    }
 };
 
 using CRoseWriter = CRosePolicy<WritePolicy>;


### PR DESCRIPTION
We need to add support for bits in the write/read policy to enable sequence bitfields support in the IDL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dev-osrose/osirose-new/221)
<!-- Reviewable:end -->
